### PR TITLE
Simple traffic monitor(WIP)

### DIFF
--- a/Linux-DSM-4.18/Makefile
+++ b/Linux-DSM-4.18/Makefile
@@ -2,7 +2,7 @@
 VERSION = 4
 PATCHLEVEL = 18
 SUBLEVEL = 20
-EXTRAVERSION = -gvm
+EXTRAVERSION = -gvm-monitor
 NAME = Merciless Moray
 
 # *DOCUMENTATION*

--- a/Linux-DSM-4.18/arch/x86/kvm/vmx.c
+++ b/Linux-DSM-4.18/arch/x86/kvm/vmx.c
@@ -7473,6 +7473,7 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 {
 	unsigned long exit_qualification;
 	gpa_t gpa;
+	gva_t gva;
 	u64 error_code;
 
 	exit_qualification = vmcs_readl(EXIT_QUALIFICATION);
@@ -7489,6 +7490,7 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 		vmcs_set_bits(GUEST_INTERRUPTIBILITY_INFO, GUEST_INTR_STATE_NMI);
 
 	gpa = vmcs_read64(GUEST_PHYSICAL_ADDRESS);
+	gva = vmcs_readl(GUEST_LINEAR_ADDRESS);
 	trace_kvm_page_fault(gpa, exit_qualification);
 
 	/* Is it a read fault? */
@@ -7508,6 +7510,13 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 
 	error_code |= (exit_qualification & 0x100) != 0 ?
 	       PFERR_GUEST_FINAL_MASK : PFERR_GUEST_PAGE_MASK;
+
+	printk("[Monitor] VCPU:%d, GVA:%lx, GPA:%llx, CR3: %lx, Flag: %s%s%s%s\n",
+			vcpu->vcpu_id, gva, gpa, vcpu->arch.mmu.get_cr3(vcpu),
+			error_code & PFERR_USER_MASK ? "R" : "_",
+			error_code & PFERR_WRITE_MASK ? "W" : "_",
+			error_code & PFERR_FETCH_MASK ? "X" : "_",
+			error_code * PFERR_PRESENT_MASK ? "P" : "_");
 
 	vcpu->arch.exit_qualification = exit_qualification;
 	return kvm_mmu_page_fault(vcpu, gpa, error_code, NULL, 0);

--- a/Linux-DSM-4.18/arch/x86/kvm/vmx.c
+++ b/Linux-DSM-4.18/arch/x86/kvm/vmx.c
@@ -7474,6 +7474,7 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 	unsigned long exit_qualification;
 	gpa_t gpa;
 	gva_t gva;
+        u64 rip;
 	u64 error_code;
 
 	exit_qualification = vmcs_readl(EXIT_QUALIFICATION);
@@ -7491,6 +7492,7 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 
 	gpa = vmcs_read64(GUEST_PHYSICAL_ADDRESS);
 	gva = vmcs_readl(GUEST_LINEAR_ADDRESS);
+	rip = (u64)vmcs_readl(GUEST_RIP);
 	trace_kvm_page_fault(gpa, exit_qualification);
 
 	/* Is it a read fault? */
@@ -7511,8 +7513,8 @@ static int handle_ept_violation(struct kvm_vcpu *vcpu)
 	error_code |= (exit_qualification & 0x100) != 0 ?
 	       PFERR_GUEST_FINAL_MASK : PFERR_GUEST_PAGE_MASK;
 
-	printk("[Monitor] VCPU:%d, GVA:%lx, GPA:%llx, CR3: %lx, Flag: %s%s%s%s\n",
-			vcpu->vcpu_id, gva, gpa, vcpu->arch.mmu.get_cr3(vcpu),
+	printk("[Monitor] VCPU:%d, GVA:%lx, GPA:%llx, RIP:%llx, CR3: %lx, Flag: %s%s%s%s\n",
+			vcpu->vcpu_id, gva, gpa, rip, vcpu->arch.mmu.get_cr3(vcpu),
 			error_code & PFERR_USER_MASK ? "R" : "_",
 			error_code & PFERR_WRITE_MASK ? "W" : "_",
 			error_code & PFERR_FETCH_MASK ? "X" : "_",

--- a/Linux-DSM-4.18/tools/monitor.py
+++ b/Linux-DSM-4.18/tools/monitor.py
@@ -1,0 +1,69 @@
+import time
+import errno
+import os
+from collections import defaultdict
+
+PAGE_MASK = 0xFFFFFFFFFFFFF000
+FILTER = "W" 
+PERIOD = 50
+CR3_INCLUDE_FILTER = []
+CR3_EXCLUDE_FILTER = [] #[0x7720a000, 0x231fe0000, 0x23183c000, 0x23183d000]
+
+end_time = time.time() + PERIOD
+histogram = defaultdict(int)
+keep_watch = True
+s_timestamp = -1
+e_timestamp = -1
+
+def parse_line(line):
+    items = l.split(",")
+    timestamp = int(items[2])/1000000
+    vcpu = items[3].split("[Monitor] VCPU:")[-1]
+    gva = int(items[4].split(" GVA:")[-1], 16) & PAGE_MASK
+    gpa = int(items[5].split(" GPA:")[-1], 16) & PAGE_MASK
+    rip = int(items[6].split(" RIP:")[-1], 16)
+    cr3 = int(items[7].split(" CR3: ")[-1], 16) & PAGE_MASK
+    flag = items[8].split(" Flag:")[-1].strip()
+    return timestamp, vcpu, gva, gpa, rip, cr3, flag
+
+while keep_watch:
+    with open("/dev/kmsg", "r") as kmsg:
+        while True:
+            if end_time < time.time():
+                keep_watch = False
+                break
+            try:
+                l = kmsg.readline()
+                if "[Monitor]" not in l:
+                    continue
+                timestamp, vcpu, gva, gpa, rip, cr3, flag = parse_line(l)
+                if FILTER not in flag:
+                    continue
+                # CR3 Filter apply
+                if CR3_INCLUDE_FILTER and cr3 not in CR3_INCLUDE_FILTER:
+                    continue
+                if cr3 in CR3_EXCLUDE_FILTER:
+                    continue
+
+                if s_timestamp == -1:
+                    s_timestamp = timestamp
+                e_timestamp = timestamp
+                histogram[rip] += 1
+                print("%0.6f %s %016x %016x %016x %016x" % (timestamp, vcpu, gva, gpa, rip, cr3), flag)
+            except IOError as e:
+                if e.errno == errno.EPIPE:
+                    continue
+                raise e 
+total = 0
+gap = e_timestamp - s_timestamp
+for key, value in histogram.items():
+    #histogram[key] /= gap
+    total += histogram[key]
+
+s = sorted(histogram, key=histogram.get)
+for key in s:
+    value = histogram[key]
+    if value < 10:
+        continue
+    print("RIP:%016x Miss: %d" % (key, value))
+print("Total %d" % total)


### PR DESCRIPTION
This is simple version of EPT monitoring tool. It handle a part of issue #7. This patch make kernel expose some metrics
- vCPU id
- Guest Physical address
- Guest Virtual address
- Guest program counter
- Guest cr3 register
- Protection attribute

Also, attached simple python script `monitor.py`. It parses metrics and report 
- most hot memory address or
- most hot program counter.

I'll attach a example below.
```
$ python monitor.py
RIP:ffffffff811c409e Miss: 5388
RIP:ffffffff81440c39 Miss: 9423
RIP:ffffffff810ec4e8 Miss: 9896
RIP:ffffffff810b88c3 Miss: 128777 <down_read_trylock>
RIP:ffffffff810b8da7 Miss: 152979 <up_read>
RIP:ffffffff8144c717 Miss: 181586 <clear_page_erms>
Total 520949
```